### PR TITLE
Update create issue link

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ In the [demo-gajira](https://github.com/atlassian/gajira-demo) repository you'll
 - [`Login`](https://github.com/marketplace/actions/jira-login) - Log in to the Jira API
 - [`CLI`](https://github.com/marketplace/actions/jira-cli) - Wrapped [go-jira](https://github.com/Netflix-Skunkworks/go-jira) CLI for common Jira actions
 - [`Find issue key`](https://github.com/marketplace/actions/jira-find) - Search for an issue key in commit message, branch name, etc. This issue key is then saved and used by the next actions in the same workflow
-- [`Create`](https://github.com/marketplace/actions/jira-create) - Create a new Jira issue
+- [`Create`](https://github.com/marketplace/actions/jira-create-issue) - Create a new Jira issue
 - [`Transition`](https://github.com/marketplace/actions/jira-transition) - Transition a Jira issue
 - [`Comment`](https://github.com/marketplace/actions/jira-comment) - Add a comment to a Jira issue
 - [`TODO`](https://github.com/marketplace/actions/jira-todo) - Create a Jira issue for each TODO comment in committed code


### PR DESCRIPTION
The `Create` actions link in the README currently points to  https://github.com/marketplace/actions/jira-create and 404s.  Updated it to point to https://github.com/marketplace/actions/jira-create-issue.